### PR TITLE
ci: update deprecated actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
          - ubuntu-latest
 #          - windows-latest
         ocaml-version:
-          - 4.14.0
+          - 4.14.2
 #          - 4.10.1
 #          - 4.09.1
 #          - 4.08.1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,9 +34,9 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.ocaml-version }}  
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: avsm/setup-ocaml@v3
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
 
       - run: opam install dune
       - name: Build project

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Try to restore opam cache
         if: runner.os != 'Windows'
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "~/.opam"
           key: ${{ matrix.os }}-${{ matrix.ocaml-version }}  


### PR DESCRIPTION
Current CI fails due to deprecated Github Actions. This PR upgrades them, yielding a working CI :tada: 

Let me know if unclear !